### PR TITLE
Improves Docs for persistenceKey

### DIFF
--- a/Sources/Provider/ProviderRequest.swift
+++ b/Sources/Provider/ProviderRequest.swift
@@ -12,7 +12,7 @@ import Networking
 public protocol ProviderRequest: NetworkRequest {
     
     /// The key to use for persistence of the request’s response.
-    /// * For single item requests, it’ll be common for the persistence key to match the provided item’s `identifier`.
+    /// * For single item requests, it’ll be common for the `persistenceKey` to match the provided item’s `identifier`.
     /// * For multiple item requests, the `persistenceKey` represents the collection of items returned as a whole.
     /// - Note: If `persistenceKey` is `nil`, `Provider` will not check the cache for item(s), and will not store the provided item(s) in the cache.
     var persistenceKey: Key? { get }


### PR DESCRIPTION
## What it Does
Gives more clarity around what `persistenceKey` is and how it _could_ differ from `identifier`.

## How I Tested

Proofread the docs.

## Notes

n/a

## Screenshot

<img width="491" alt="Screen Shot 2020-11-20 at 2 24 34 PM" src="https://user-images.githubusercontent.com/7883805/99841423-27c22880-2b3c-11eb-96b9-94d2d6157710.png">


