### PR TITLE
Making ignoresCache default implementation public

### DIFF
--- a/Sources/Provider/ProviderRequest.swift
+++ b/Sources/Provider/ProviderRequest.swift
@@ -21,7 +21,7 @@ public protocol ProviderRequest: NetworkRequest {
     var ignoresCachedContent: Bool { get }
 }
 
-extension ProviderRequest {
+public extension ProviderRequest {
     
     var ignoresCachedContent: Bool {
         switch httpMethod {


### PR DESCRIPTION
## What it Does

- Make the default implementation extension public so you can use it in an app.