### PR TITLE
Switches Dependencies To Tagged Releases

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,18 +5,18 @@
         "package": "Networking",
         "repositoryURL": "https://github.com/Lickability/Networking",
         "state": {
-          "branch": "main",
-          "revision": "33745f3dc8c5db31d197ae2c891ebac09bde51a8",
-          "version": null
+          "branch": null,
+          "revision": "54ba83b22a932e870a4e99f3176a34c810c7c2c2",
+          "version": "1.0.0"
         }
       },
       {
         "package": "Persister",
         "repositoryURL": "https://github.com/Lickability/Persister",
         "state": {
-          "branch": "main",
-          "revision": "e2c48a5550d4f2a5601d25018cb75030439363af",
-          "version": null
+          "branch": null,
+          "revision": "556198feaa1b37cfb54328af43dcb2709002972a",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Lickability/Networking",
-            .branch("main")
+            .upToNextMajor(from: "1.0.0")
         ),
         .package(
             url: "https://github.com/Lickability/Persister",
-            .branch("main")
+            .upToNextMajor(from: "1.0.0")
         )
     ],
     targets: [.target(name: name, dependencies: ["Networking", "Persister"], resources: [.process("Resources")])]


### PR DESCRIPTION
## What it Does
Switches dependency versions to a tagged release instead of pointing to `main`.

## How I Tested
Made sure the project and package still compile.
