### PR TITLE
Add FetchPolicy API to Allow Fetching from Cache And Network Each Time

### DIFF
--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -40,7 +40,7 @@ public final class ItemProvider {
     ///   - networkRequestPerformer: Performs network requests when items cannot be retrieved from persistence.
     ///   - cache: The cache used to persist / recall previously retrieved items.
     ///   - defaultProviderBehaviors: Actions to perform before _every_ provider request is performed and / or after _every_ provider request is completed.
-    public init(networkRequestPerformer: NetworkRequestPerformer, cache: Cache?, fetchPolicy: FetchPolicy, defaultProviderBehaviors: [ProviderBehavior] = []) {
+    public init(networkRequestPerformer: NetworkRequestPerformer, cache: Cache?, fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, defaultProviderBehaviors: [ProviderBehavior] = []) {
         self.networkRequestPerformer = networkRequestPerformer
         self.cache = cache
         self.fetchPolicy = fetchPolicy

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -129,7 +129,11 @@ extension ItemProvider: Provider {
                             return itemPublisher
                         }
                     case .returnFromCacheAndNetwork:
-                        return cachedItemAndNetworkPublisher
+                        if !allowExpiredItem && isItemExpired {
+                            return networkPublisher
+                        } else {
+                            return cachedItemAndNetworkPublisher
+                        }
                     }
                 } else {
                     return networkPublisher
@@ -216,7 +220,11 @@ extension ItemProvider: Provider {
                             return itemPublisher
                         }
                     case .returnFromCacheAndNetwork:
-                        return cachedItemsAndNetworkPublisher
+                        if !allowExpiredItems && areItemsExpired {
+                            return networkPublisher
+                        } else {
+                            return cachedItemsAndNetworkPublisher
+                        }
                     }
                 } else {
                     return networkPublisher

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -13,12 +13,13 @@ import Persister
 
 /// Retrieves items from persistence or networking and stores them in persistence.
 public final class ItemProvider {
+    
     /// The policy for how the provider checks the cache and/or the network for items.
     public enum FetchPolicy {
-        /// Only request from the network if we don't have items in the cache.
+        /// Only request from the network if we don't have items in the cache. If items exist in the cache and are expired, it returns items from the cache and the network.
         case returnFromCacheElseNetwork
         
-        /// Return data from the cache, then request from the network for updated items.
+        /// Return items from the cache, then request from the network for updated items.
         case returnFromCacheAndNetwork
     }
     
@@ -39,6 +40,7 @@ public final class ItemProvider {
     /// - Parameters:
     ///   - networkRequestPerformer: Performs network requests when items cannot be retrieved from persistence.
     ///   - cache: The cache used to persist / recall previously retrieved items.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - defaultProviderBehaviors: Actions to perform before _every_ provider request is performed and / or after _every_ provider request is completed.
     public init(networkRequestPerformer: NetworkRequestPerformer, cache: Cache?, fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, defaultProviderBehaviors: [ProviderBehavior] = []) {
         self.networkRequestPerformer = networkRequestPerformer


### PR DESCRIPTION
## What it Does

This pull request adds a new API to `ItemProvider` to control its fetching behavior. This was inspired by an app we're working on where we want to both fetch content from the cache _and_ the network each time, and I realized that there isn't a great way for `ItemProvider` to do so right now. This makes the behavior more explicit in the public API, as well as additional functionality, as it is technically possible to achieve this now by expiring every item immediately and marking every call to `provide` as `allowsExpiredItems`.

## How I Tested

* Implemented this API on a branch in another app
* Launched with network and verified everything was cached
* Re-launched without network and verified with breakpoints that the `cachedItemAndNetworkPublisher` was returned and that the cached data was returned and a network error was shown, as expected.