### PR TITLE
Swift 6 and Concurrency update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Lickability/Networking",
         "state": {
           "branch": null,
-          "revision": "c7013a352d5a52ed433a34b7af50b3bc008d37cb",
-          "version": "2.2.2"
+          "revision": "89772986b8c38ed33dfcf2e7e89e649280c35049",
+          "version": "3.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Lickability/Persister",
         "state": {
           "branch": null,
-          "revision": "556198feaa1b37cfb54328af43dcb2709002972a",
-          "version": "1.0.0"
+          "revision": "f51e2226f0c8b0c9c37ded2739a42181accf2953",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,7 @@ let name = "Provider"
 let package = Package(
     name: name,
     defaultLocalization: "en",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v16)],
     products: [.library(name: name, targets: [name])],
     dependencies: [
         .package(

--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Lickability/Networking",
-            .upToNextMajor(from: "2.0.0")
+            .upToNextMajor(from: "3.0.0")
         ),
         .package(
             url: "https://github.com/Lickability/Persister",
-            .upToNextMajor(from: "1.0.0")
+            .upToNextMajor(from: "2.0.0")
         )
     ],
     targets: [.target(name: name, dependencies: ["Networking", "Persister"], resources: [.process("Resources")])]

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -626,8 +626,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lickability/Networking";
 			requirement = {
-				branch = "feature/swift-6";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
 			};
 		};
 		F27A5791250BF23900FBAD8F /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -616,8 +616,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lickability/Persister";
 			requirement = {
-				branch = "feature/swift-6";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
 			};
 		};
 		4CC4416124E6F7EB00F48427 /* XCRemoteSwiftPackageReference "Networking" */ = {
@@ -633,7 +633,7 @@
 			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 9.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -623,8 +623,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lickability/Networking";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.2;
+				branch = "feature/swift-6";
+				kind = branch;
 			};
 		};
 		F27A5791250BF23900FBAD8F /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -260,7 +260,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1610;
 				ORGANIZATIONNAME = Lickability;
 				TargetAttributes = {
 					4C04A60124E6EEBA00D73E0E = {
@@ -379,6 +379,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -442,6 +443,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -258,8 +258,9 @@
 		4C04A5FA24E6EEBA00D73E0E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = Lickability;
 				TargetAttributes = {
 					4C04A60124E6EEBA00D73E0E = {
@@ -411,6 +412,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -473,6 +475,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -537,7 +540,6 @@
 		4C04A62524E6EEBC00D73E0E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
@@ -559,7 +561,6 @@
 		4C04A62624E6EEBC00D73E0E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;

--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -486,6 +487,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -499,6 +501,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -519,6 +522,7 @@
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -538,7 +542,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -560,7 +564,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JL4AKR8DVC;
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -611,7 +615,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Lickability/Persister";
 			requirement = {
-				branch = main;
+				branch = "feature/swift-6";
 				kind = branch;
 			};
 		};

--- a/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Networking",
       "state" : {
-        "revision" : "c7013a352d5a52ed433a34b7af50b3bc008d37cb",
-        "version" : "2.2.2"
+        "branch" : "feature/swift-6",
+        "revision" : "b3e0b281c33c6d4166b46420b11505b629633c7b"
       }
     },
     {

--- a/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
       "state" : {
-        "revision" : "e92b5a5746ef16add2a1424f1fc19529d9a75cde",
-        "version" : "9.0.0"
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Persister",
       "state" : {
-        "branch" : "feature/swift-6",
-        "revision" : "a9251d506d2c2b56f0d6004ebb6dd2dd4a5d5d73"
+        "revision" : "f51e2226f0c8b0c9c37ded2739a42181accf2953",
+        "version" : "2.0.0"
       }
     }
   ],

--- a/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Persister",
       "state" : {
-        "branch" : "main",
-        "revision" : "ac8f39433b3ced5df28f6c414d06ddc50a57ba7c"
+        "branch" : "feature/swift-6",
+        "revision" : "a9251d506d2c2b56f0d6004ebb6dd2dd4a5d5d73"
       }
     }
   ],

--- a/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Provider.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Networking",
       "state" : {
-        "branch" : "feature/swift-6",
-        "revision" : "b3e0b281c33c6d4166b46420b11505b629633c7b"
+        "revision" : "89772986b8c38ed33dfcf2e7e89e649280c35049",
+        "version" : "3.0.0"
       }
     },
     {

--- a/Sources/Provider/Identifiable.swift
+++ b/Sources/Provider/Identifiable.swift
@@ -12,7 +12,7 @@ import Foundation
 public typealias Key = String
 
 /// Describes a type that can be uniquely identified by a `Key`.
-public protocol Identifiable {
+public protocol Identifiable: Sendable {
     
     /// The key used to uniquely identify the receiver.
     var identifier: Key { get }

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -7,15 +7,15 @@
 //
 
 import Foundation
-import Combine
-import Networking
+@preconcurrency import Combine
+@preconcurrency import Networking
 import Persister
 
 /// Retrieves items from persistence or networking and stores them in persistence.
-public final class ItemProvider {
+public final class ItemProvider: Sendable {
     
     /// The policy for how the provider checks the cache and/or the network for items.
-    public enum FetchPolicy {
+    public enum FetchPolicy: Sendable {
         /// Only request from the network if we don't have items in the cache. If items exist in the cache and are expired, it returns items from the cache and the network.
         case returnFromCacheElseNetwork
         

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Combine
-@preconcurrency import Networking
+import Networking
 import Persister
 
 /// Retrieves items from persistence or networking and stores them in persistence.

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -12,7 +12,7 @@ import Combine
 import Persister
 
 /// Retrieves items from persistence or networking and stores them in persistence.
-public final class ItemProvider {
+public final class ItemProvider: Sendable {
     
     /// The policy for how the provider checks the cache and/or the network for items.
     public enum FetchPolicy: Sendable {

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@preconcurrency import Combine
+import Combine
 @preconcurrency import Networking
 import Persister
 
@@ -34,7 +34,7 @@ public final class ItemProvider: Sendable {
     private let fetchPolicy: FetchPolicy
     private let defaultProviderBehaviors: [ProviderBehavior]
     private let providerQueue = DispatchQueue(label: "ProviderQueue", attributes: .concurrent)
-    private var cancellables = Set<AnyCancellable?>()
+    nonisolated(unsafe) private var cancellables = Set<AnyCancellable?>()
     
     /// Creates a new `ItemProvider`.
     /// - Parameters:
@@ -57,7 +57,7 @@ extension ItemProvider: Provider {
     @discardableResult
     public func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItem: Bool = false, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable? {
         
-        var cancellable: AnyCancellable?
+        nonisolated(unsafe) var cancellable: AnyCancellable?
         cancellable = provide(request: request,
                      decoder: decoder,
                      providerBehaviors: providerBehaviors,
@@ -84,7 +84,7 @@ extension ItemProvider: Provider {
     @discardableResult
     public func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable? {
         
-        var cancellable: AnyCancellable?
+        nonisolated(unsafe) var cancellable: AnyCancellable?
         cancellable = provideItems(request: request,
                      decoder: decoder,
                      providerBehaviors: providerBehaviors,

--- a/Sources/Provider/ProvideItemRequestStateController.swift
+++ b/Sources/Provider/ProvideItemRequestStateController.swift
@@ -110,6 +110,7 @@ public final class ProvideItemRequestStateController<Item: Providable> {
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
+    @MainActor
     public func provide(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItem: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 

--- a/Sources/Provider/ProvideItemRequestStateController.swift
+++ b/Sources/Provider/ProvideItemRequestStateController.swift
@@ -9,10 +9,10 @@
 import Foundation
 import Networking
 import Persister
-import Combine
+@preconcurrency import Combine
 
 /// A class responsible for representing the state and value of a provider item request being made.
-public final class ProvideItemRequestStateController<Item: Providable> {
+public final class ProvideItemRequestStateController<Item: Providable>: Sendable {
     
     /// The state of a provider request's lifecycle.
     public enum ProvideItemRequestState {
@@ -87,18 +87,19 @@ public final class ProvideItemRequestStateController<Item: Providable> {
     }
     
     /// A `Publisher` that can be subscribed to in order to receive updates about the status of a request.
-    public private(set) lazy var publisher: AnyPublisher<ProvideItemRequestState, Never> = {
-        return providerStatePublisher.prepend(.notInProgress).eraseToAnyPublisher()
-    }()
+    public let publisher: AnyPublisher<ProvideItemRequestState, Never>
     
     private let provider: Provider
-    private let providerStatePublisher = PassthroughSubject<ProvideItemRequestState, Never>()
-    private var cancellables = Set<AnyCancellable>()
+    private let providerStatePublisher: PassthroughSubject<ProvideItemRequestState, Never>
+    private let cancellablesQueue = DispatchQueue(label: "com.lickability.Provider.ProvideItemRequestStateController.cancellable.queue")
+    nonisolated(unsafe) private var cancellables = Set<AnyCancellable>()
     
     /// Initializes the `ProvideItemRequestStateController` with the specified parameters.
     /// - Parameter provider: The `Provider` used to provide a response from.
     public init(provider: Provider) {
         self.provider = provider
+        self.providerStatePublisher = PassthroughSubject<ProvideItemRequestState, Never>()
+        self.publisher = providerStatePublisher.prepend(.notInProgress).eraseToAnyPublisher()
     }
             
     /// Sends a request with the specified parameters to provide back an item.
@@ -114,20 +115,25 @@ public final class ProvideItemRequestStateController<Item: Providable> {
     public func provide(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItem: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 
-        provider.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
+        let cancellable = provider.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
             .retry(retryCount)
             .mapAsResult()
             .receive(on: scheduler)
             .sink { [providerStatePublisher] result in
                 providerStatePublisher.send(.completed(result))
             }
-            .store(in: &cancellables)
+        
+        _ = cancellablesQueue.sync {
+            cancellables.insert(cancellable)
+        }
     }
         
     /// Resets the state of the `providerStatePublisher` and cancels any in flight requests that may be ongoing. Cancellation is not guaranteed, and requests that are near completion may end up finishing, despite being cancelled.
     public func resetState() {
-        cancellables.forEach { $0.cancel() }
-        cancellables.removeAll()
+        cancellablesQueue.sync {
+            cancellables.forEach { $0.cancel() }
+            cancellables.removeAll()
+        }
 
         providerStatePublisher.send(.notInProgress)
     }

--- a/Sources/Provider/ProvideItemsRequestStateController.swift
+++ b/Sources/Provider/ProvideItemsRequestStateController.swift
@@ -110,6 +110,7 @@ public final class ProvideItemsRequestStateController<Item: Providable> {
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
+    @MainActor
     public func provideItems(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItems: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 

--- a/Sources/Provider/ProvideItemsRequestStateController.swift
+++ b/Sources/Provider/ProvideItemsRequestStateController.swift
@@ -12,6 +12,7 @@ import Persister
 @preconcurrency import Combine
 
 /// A class responsible for representing the state and value of a provider items request being made.
+@MainActor
 public final class ProvideItemsRequestStateController<Item: Providable>: Sendable {
     
     /// The state of a provider request's lifecycle.
@@ -91,8 +92,7 @@ public final class ProvideItemsRequestStateController<Item: Providable>: Sendabl
     
     private let provider: Provider
     private let providerStatePublisher: PassthroughSubject<ProvideItemsRequestState, Never>
-    private let cancellablesQueue = DispatchQueue(label: "com.lickability.Provider.ProvideItemsRequestStateController.cancellable.queue")
-    nonisolated(unsafe) private var cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
     
     /// Initializes the `ProvideItemsRequestStateController` with the specified parameters.
     /// - Parameter provider: The `Provider` used to provide a response from.
@@ -111,30 +111,23 @@ public final class ProvideItemsRequestStateController<Item: Providable>: Sendabl
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
-    @MainActor
     public func provideItems(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItems: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 
-        let cancellable =  provider.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: allowExpiredItems)
+        provider.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: allowExpiredItems)
             .retry(retryCount)
             .mapAsResult()
             .receive(on: scheduler)
             .sink { [providerStatePublisher] result in
                 providerStatePublisher.send(.completed(result))
             }
-        
-        _ = cancellablesQueue.sync {
-            cancellables.insert(cancellable)
-        }
+            .store(in: &cancellables)
     }
     
     /// Resets the state of the `providerStatePublisher` and cancels any in flight requests that may be ongoing. Cancellation is not guaranteed, and requests that are near completion may end up finishing, despite being cancelled.
     public func resetState() {
-        cancellablesQueue.sync {
-            cancellables.forEach { $0.cancel() }
-            cancellables.removeAll()
-        }
-
+        cancellables.forEach { $0.cancel() }
+        cancellables.removeAll()
         providerStatePublisher.send(.notInProgress)
     }
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -12,7 +12,7 @@ import Networking
 import Persister
 
 /// Represents the type of an instance that can be retrieved by a `Provider`.
-public typealias Providable = Codable & Identifiable
+public typealias Providable = Codable & Identifiable & Sendable
 
 /// Describes a type that can retrieve items from persistence or networking and store them in persistence.
 public protocol Provider {

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -15,7 +15,7 @@ import Persister
 public typealias Providable = Codable & Identifiable & Sendable
 
 /// Describes a type that can retrieve items from persistence or networking and store them in persistence.
-public protocol Provider {
+public protocol Provider: Sendable {
     
     /// Attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success. If `allowExpiredItem` is true, and an expired item exists, the `itemHandler` will first be called with the expired item, and then called again with the result of the network request.
     /// - Parameters:
@@ -27,6 +27,7 @@ public protocol Provider {
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     ///   - itemHandler: The closure called upon completing the request that provides the desired item or the error that occurred when attempting to retrieve it.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
+    @MainActor
     @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
     
     /// Attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success. If `allowExpiredItems` is true, and the expired items exist, the `itemHandler` will first be called with the expired items, and then called again with the result of the network request.
@@ -39,6 +40,7 @@ public protocol Provider {
     ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If expired items are returned, the completion will be called for both the expired items, and the items retrieved from the network when available.
     ///   - itemsHandler: The closure called upon completing the request that provides the desired items or the error that occurred when attempting to retrieve them.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
+    @MainActor
     @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success.
@@ -48,6 +50,7 @@ public protocol Provider {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItem: Allows the publisher to publish an expired item from the cache. If an expired item is published, this publisher will then also publish an up to date item from the network when it is available.
+    @MainActor
     func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItem: Bool) -> AnyPublisher<Item, ProviderError>
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success.
@@ -57,6 +60,7 @@ public protocol Provider {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItems: Allows the publisher to publish expired items from the cache. If expired items are published, this publisher will then also publish up to date results from the network when they are available.
+    @MainActor
     func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
     
     /// Returns a item or a `ProviderError` after the async operation has been completed.

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -15,6 +15,7 @@ import Persister
 public typealias Providable = Codable & Identifiable & Sendable
 
 /// Describes a type that can retrieve items from persistence or networking and store them in persistence.
+@MainActor
 public protocol Provider: Sendable {
     
     /// Attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success. If `allowExpiredItem` is true, and an expired item exists, the `itemHandler` will first be called with the expired item, and then called again with the result of the network request.
@@ -27,7 +28,6 @@ public protocol Provider: Sendable {
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     ///   - itemHandler: The closure called upon completing the request that provides the desired item or the error that occurred when attempting to retrieve it.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @MainActor
     @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
     
     /// Attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success. If `allowExpiredItems` is true, and the expired items exist, the `itemHandler` will first be called with the expired items, and then called again with the result of the network request.
@@ -40,7 +40,6 @@ public protocol Provider: Sendable {
     ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If expired items are returned, the completion will be called for both the expired items, and the items retrieved from the network when available.
     ///   - itemsHandler: The closure called upon completing the request that provides the desired items or the error that occurred when attempting to retrieve them.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @MainActor
     @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success.
@@ -50,7 +49,6 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItem: Allows the publisher to publish an expired item from the cache. If an expired item is published, this publisher will then also publish an up to date item from the network when it is available.
-    @MainActor
     func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItem: Bool) -> AnyPublisher<Item, ProviderError>
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success.
@@ -60,7 +58,6 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItems: Allows the publisher to publish expired items from the cache. If expired items are published, this publisher will then also publish up to date results from the network when they are available.
-    @MainActor
     func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
     
     /// Returns a item or a `ProviderError` after the async operation has been completed.

--- a/Sources/Provider/ProviderBehavior.swift
+++ b/Sources/Provider/ProviderBehavior.swift
@@ -22,11 +22,6 @@ public protocol ProviderBehavior: Sendable {
     func providerDidProvide<Item: Codable>(item: Item, forRequest request: any ProviderRequest)
 }
 
-extension ProviderBehavior {
-    func providerWillProvide(forRequest request: any ProviderRequest) { }
-    func providerDidProvide<Item: Codable>(item: Item, forRequest request: any ProviderRequest) { }
-}
-
 extension Array: ProviderBehavior where Element == ProviderBehavior {
     public func providerWillProvide(forRequest request: any ProviderRequest) {
         forEach { $0.providerWillProvide(forRequest: request) }

--- a/Sources/Provider/ProviderBehavior.swift
+++ b/Sources/Provider/ProviderBehavior.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Describes a type that can be used to implement behaviors for provider requests.
-public protocol ProviderBehavior {
+public protocol ProviderBehavior: Sendable {
     
     /// Called before a provider request is performed.
     /// - Parameter request: The request that will be made.

--- a/Sources/Provider/ProviderError.swift
+++ b/Sources/Provider/ProviderError.swift
@@ -16,7 +16,7 @@ public indirect enum ProviderError: LocalizedError {
     // MARK: - ProviderError
     
     /// A struct that represents a failure when retrieving an individual item during a request for multiple items.
-    public struct PartialRetrievalFailure {
+    public struct PartialRetrievalFailure: Sendable {
         
         /// They key for the item that failed to be retrieved.
         let key: String

--- a/Sources/Provider/ProviderError.swift
+++ b/Sources/Provider/ProviderError.swift
@@ -11,7 +11,7 @@ import Networking
 import Persister
 
 /// Possible errors encountered while attempting to provide items.
-public indirect enum ProviderError: LocalizedError {
+public indirect enum ProviderError: LocalizedError, Sendable {
     
     // MARK: - ProviderError
     

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -16,6 +16,7 @@ import Persister
 
 @testable import Provider
 
+@MainActor
 final class ItemProviderTests_Async: XCTestCase {
 
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
@@ -29,13 +30,11 @@ final class ItemProviderTests_Async: XCTestCase {
     private var cancellables = Set<AnyCancellable>()
     private lazy var itemPath = OHPathForFile("Item.json", type(of: self))!
     private lazy var itemsPath = OHPathForFile("Items.json", type(of: self))!
-
-    override func tearDown() {
+    
+    override func tearDown() async throws {
         HTTPStubs.removeAllStubs()
         try? provider.cache?.removeAll()
         try? expiredProvider.cache?.removeAll()
-        
-        super.tearDown()
     }
     
     // MARK: - Async Provide Items Tests

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -20,7 +20,7 @@ final class ItemProviderTests_Async: XCTestCase {
 
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
     private let expiredProvider: ItemProvider = {
-        let networkController = NetworkController(urlSession: .shared, defaultRequestBehaviors: [])
+        let networkController = NetworkController()
         let cache = Persister(memoryCache: MemoryCache(capacity: .unlimited, expirationPolicy: .afterInterval(-1)), diskCache: DiskCache(rootDirectoryURL: FileManager.default.cachesDirectoryURL, expirationPolicy: .afterInterval(-1)))
         
         return ItemProvider(networkRequestPerformer: networkController, cache: cache)

--- a/Tests/ItemProviderTests.swift
+++ b/Tests/ItemProviderTests.swift
@@ -40,6 +40,7 @@ class ItemProviderTests: XCTestCase {
     
     // MARK: - Item Provider Item Handler Tests
 
+    @MainActor
     func testProvideItem() {
         let request = TestProviderRequest()
         
@@ -62,6 +63,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
         
+    @MainActor
     func testProvideItemReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -98,6 +100,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemReturnsExpiredItemInBothCompletions() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The item will be returned in both closures.")
@@ -120,6 +123,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemFailure() {
         let request = TestProviderRequest()
         
@@ -142,6 +146,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItems() {
         let request = TestProviderRequest()
         
@@ -165,6 +170,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -201,6 +207,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsReturnsExpiredItemInBothCompletions() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The items will be returned in both closures.")
@@ -224,6 +231,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
+    @MainActor
     func testProvideItemsReturnsPartialResponseUponFailure() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -275,6 +283,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsDoesNotReturnPartialResponseUponFailureForExpiredItems() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -310,6 +319,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsFailure() {
         let request = TestProviderRequest()
         
@@ -332,6 +342,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemSkipsCacheOnPostRequest() {
         let key = "TestPostKey"
         let request = TestPostProviderRequest(key: key)
@@ -361,6 +372,7 @@ class ItemProviderTests: XCTestCase {
     
     // MARK: - Item Provider Publisher Tests
     
+    @MainActor
     func testProvideItemPublisher() {
         let request = TestProviderRequest()
         
@@ -381,6 +393,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemPublisherFailure() {
         let request = TestProviderRequest()
         
@@ -403,6 +416,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemPublisherReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -433,6 +447,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemPublisherPublishesExpiredItem() {
         let request = TestProviderRequest()
         
@@ -457,6 +472,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisher() {
         let request = TestProviderRequest()
         
@@ -478,6 +494,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisherFailure() {
         let request = TestProviderRequest()
         
@@ -499,6 +516,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisherReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -530,6 +548,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisherPublishesExpiredItems() {
         let request = TestProviderRequest()
         
@@ -554,6 +573,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisherReturnsPartialResponseUponFailure() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -612,6 +632,7 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
+    @MainActor
     func testProvideItemsPublisherDoesNotReturnPartialResponseUponFailureForExpiredItems() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")

--- a/Tests/ItemProviderTests.swift
+++ b/Tests/ItemProviderTests.swift
@@ -16,6 +16,7 @@ import Persister
 
 @testable import Provider
 
+@MainActor
 class ItemProviderTests: XCTestCase {
     
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
@@ -40,7 +41,6 @@ class ItemProviderTests: XCTestCase {
     
     // MARK: - Item Provider Item Handler Tests
 
-    @MainActor
     func testProvideItem() {
         let request = TestProviderRequest()
         
@@ -62,8 +62,7 @@ class ItemProviderTests: XCTestCase {
         
         wait(for: [expectation], timeout: 2)
     }
-        
-    @MainActor
+    
     func testProvideItemReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -100,7 +99,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemReturnsExpiredItemInBothCompletions() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The item will be returned in both closures.")
@@ -123,7 +121,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemFailure() {
         let request = TestProviderRequest()
         
@@ -146,7 +143,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItems() {
         let request = TestProviderRequest()
         
@@ -170,7 +166,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -207,7 +202,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsReturnsExpiredItemInBothCompletions() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The items will be returned in both closures.")
@@ -231,7 +225,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
 
-    @MainActor
     func testProvideItemsReturnsPartialResponseUponFailure() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -283,7 +276,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsDoesNotReturnPartialResponseUponFailureForExpiredItems() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -319,7 +311,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsFailure() {
         let request = TestProviderRequest()
         
@@ -342,7 +333,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemSkipsCacheOnPostRequest() {
         let key = "TestPostKey"
         let request = TestPostProviderRequest(key: key)
@@ -372,7 +362,6 @@ class ItemProviderTests: XCTestCase {
     
     // MARK: - Item Provider Publisher Tests
     
-    @MainActor
     func testProvideItemPublisher() {
         let request = TestProviderRequest()
         
@@ -393,7 +382,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemPublisherFailure() {
         let request = TestProviderRequest()
         
@@ -416,7 +404,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemPublisherReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -447,7 +434,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemPublisherPublishesExpiredItem() {
         let request = TestProviderRequest()
         
@@ -472,7 +458,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisher() {
         let request = TestProviderRequest()
         
@@ -494,7 +479,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisherFailure() {
         let request = TestProviderRequest()
         
@@ -516,7 +500,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisherReturnsCachedResult() {
         let request = TestProviderRequest()
         
@@ -548,7 +531,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisherPublishesExpiredItems() {
         let request = TestProviderRequest()
         
@@ -573,7 +555,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisherReturnsPartialResponseUponFailure() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")
@@ -632,7 +613,6 @@ class ItemProviderTests: XCTestCase {
         wait(for: [expectation], timeout: 2)
     }
     
-    @MainActor
     func testProvideItemsPublisherDoesNotReturnPartialResponseUponFailureForExpiredItems() {
         let request = TestProviderRequest()
         let expectation = self.expectation(description: "The provider will return a partial response.")

--- a/Tests/ItemProviderTests.swift
+++ b/Tests/ItemProviderTests.swift
@@ -20,7 +20,7 @@ class ItemProviderTests: XCTestCase {
     
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
     private let expiredProvider: ItemProvider = {
-        let networkController = NetworkController(urlSession: .shared, defaultRequestBehaviors: [])
+        let networkController = NetworkController()
         let cache = Persister(memoryCache: MemoryCache(capacity: .unlimited, expirationPolicy: .afterInterval(-1)), diskCache: DiskCache(rootDirectoryURL: FileManager.default.cachesDirectoryURL, expirationPolicy: .afterInterval(-1)))
         
         return ItemProvider(networkRequestPerformer: networkController, cache: cache)

--- a/Tests/ItemProviderTests.swift
+++ b/Tests/ItemProviderTests.swift
@@ -31,12 +31,10 @@ class ItemProviderTests: XCTestCase {
     private lazy var itemPath = OHPathForFile("Item.json", type(of: self))!
     private lazy var itemsPath = OHPathForFile("Items.json", type(of: self))!
 
-    override func tearDown() {
+    override func tearDown() async throws {
         HTTPStubs.removeAllStubs()
         try? provider.cache?.removeAll()
         try? expiredProvider.cache?.removeAll()
-        
-        super.tearDown()
     }
     
     // MARK: - Item Provider Item Handler Tests


### PR DESCRIPTION
## What it Does
- Updates Provider to have strict concurrency turned on as well as Swift 6
- Goes through and conforms various types to `Sendable`
- Uses `nonisolated(unsafe)` and then manually manages the thread safety when needed for mutability.

## How I Tested
- Built the app, ran the test repeatedly 100 times to make sure they pass

## Notes
- There is an issue where if you call one of the combine based network calls from the main thread and then do things on any other thread as part of the returned combine chain, the app will crash without a compiler warning. Used `@MainActor` to enforce it being called from the thread and then always receiving on that thread. I can't scope it to something like the MainQueueScheduler we have in ViewStore, so I updated the docs to call it out.
- Most of the places we are using `nonisolated(unsafe)` we likely should move from classes to actors so that their mutable state is thread safe without managing it ourselves.
- That felt like a bigger change so will be a follow refactor
