### PR TITLE
Updated the Provider Package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Networking",
       "state" : {
-        "revision" : "2ca427c34191edc4c86e52c6256056bc580b1fc6",
-        "version" : "3.0.2"
+        "version" : "3.0.2",
+        "revision" : "2ca427c34191edc4c86e52c6256056bc580b1fc6"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lickability/Networking",
       "state" : {
-        "branch" : "kpa/main-actor-removal",
-        "revision" : "1b9dfca5590875618940d3e10912f89b4c644e77"
+        "revision" : "2ca427c34191edc4c86e52c6256056bc580b1fc6",
+        "version" : "3.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Lickability/Networking",
-            branch: "kpa/main-actor-removal"
+            .upToNextMajor(from: "3.0.2")
         ),
         .package(
             url: "https://github.com/Lickability/Persister",


### PR DESCRIPTION
## What it Does
- Updates the package resolve and package.swift again. When I tried the changes made here in the release https://github.com/Lickability/Provider/pull/25. Nothing would show up.
- Updated the Package.swift file to use the upNaxtMajor version rather than a branch. Also updated the package resolve to do the same. 
## How I Tested
Made sure package built.