### PR TITLE
Moving fetch policy to functions instead of on the type

### DIFF
--- a/Provider.xcodeproj/project.pbxproj
+++ b/Provider.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0B3FF2BA2D9C2CC70079DD54 /* Dates.json in Resources */ = {isa = PBXBuildFile; fileRef = 0B3FF2B92D9C2CBF0079DD54 /* Dates.json */; };
 		0B3FF2BC2D9C2D700079DD54 /* TestDateContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3FF2BB2D9C2D700079DD54 /* TestDateContainer.swift */; };
+		1DA4AF3D2E130E6100ABBBA9 /* FetchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA4AF3C2E130E6100ABBBA9 /* FetchPolicy.swift */; };
 		2E19FDC62B5719B20026925A /* ItemProviderTest+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E19FDC52B5719B20026925A /* ItemProviderTest+Async.swift */; };
 		2E19FDC82B5720580026925A /* FileManager+CachesDirectoryURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E19FDC72B5720580026925A /* FileManager+CachesDirectoryURL.swift */; };
 		2E19FDCA2B57208F0026925A /* TestProviderRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E19FDC92B57208F0026925A /* TestProviderRequest.swift */; };
@@ -52,6 +53,7 @@
 /* Begin PBXFileReference section */
 		0B3FF2B92D9C2CBF0079DD54 /* Dates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Dates.json; sourceTree = "<group>"; };
 		0B3FF2BB2D9C2D700079DD54 /* TestDateContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDateContainer.swift; sourceTree = "<group>"; };
+		1DA4AF3C2E130E6100ABBBA9 /* FetchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPolicy.swift; sourceTree = "<group>"; };
 		2E19FDC52B5719B20026925A /* ItemProviderTest+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ItemProviderTest+Async.swift"; sourceTree = "<group>"; };
 		2E19FDC72B5720580026925A /* FileManager+CachesDirectoryURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+CachesDirectoryURL.swift"; sourceTree = "<group>"; };
 		2E19FDC92B57208F0026925A /* TestProviderRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProviderRequest.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 			children = (
 				F2BE3774254CAF2A0062C317 /* Resources */,
 				4C6B41A024F9561300BE6D45 /* ProviderBehavior.swift */,
+				1DA4AF3C2E130E6100ABBBA9 /* FetchPolicy.swift */,
 				4C6B419E24F9561300BE6D45 /* Provider.swift */,
 				4C6B419F24F9561300BE6D45 /* ProviderRequest.swift */,
 				4C6B41A124F9561300BE6D45 /* Identifiable.swift */,
@@ -343,6 +346,7 @@
 				4C04A60824E6EEBA00D73E0E /* SceneDelegate.swift in Sources */,
 				4C6B41A724F9561300BE6D45 /* Identifiable.swift in Sources */,
 				4C6B41A524F9561300BE6D45 /* ProviderRequest.swift in Sources */,
+				1DA4AF3D2E130E6100ABBBA9 /* FetchPolicy.swift in Sources */,
 				4C04A60A24E6EEBA00D73E0E /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Provider/FetchPolicy.swift
+++ b/Sources/Provider/FetchPolicy.swift
@@ -1,0 +1,19 @@
+//
+//  FetchPolicy.swift
+//  Provider
+//
+//  Created by Michael Amundsen on 6/30/25.
+//  Copyright © 2025 Lickability. All rights reserved.
+//
+
+import Foundation
+
+/// The policy for how the provider checks the cache and/or the network for items.
+public enum FetchPolicy: Sendable {
+    
+    /// Only request from the network if we don't have items in the cache. If items exist in the cache and are expired, it returns items from the cache and the network.
+    case returnFromCacheElseNetwork
+    
+    /// Return items from the cache, then request from the network for updated items.
+    case returnFromCacheAndNetwork
+}

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -262,17 +262,29 @@ extension ItemProvider: Provider {
     
     public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<Item, ProviderError> {
         await withCheckedContinuation { continuation in
-            provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { result in
+            var cancellable: AnyCancellable?
+            cancellable = provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { [weak self] result in
                 continuation.resume(returning: result)
+                
+                cancellable?.cancel()
+                self?.removeCancellable(cancellable: cancellable)
             }
+            
+            insertCancellable(cancellable: cancellable)
         }
     }
     
     public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<[Item], ProviderError> {
         await withCheckedContinuation { continuation in
-            provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { result in
+            var cancellable: AnyCancellable?
+            cancellable = provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { [weak self] result in
                 continuation.resume(returning: result)
+                
+                cancellable?.cancel()
+                self?.removeCancellable(cancellable: cancellable)
             }
+            
+            insertCancellable(cancellable: cancellable)
         }
     }
     

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -11,16 +11,6 @@ import Combine
 import Networking
 import Persister
 
-/// The policy for how the provider checks the cache and/or the network for items.
-public enum FetchPolicy: Sendable {
-    
-    /// Only request from the network if we don't have items in the cache. If items exist in the cache and are expired, it returns items from the cache and the network.
-    case returnFromCacheElseNetwork
-    
-    /// Return items from the cache, then request from the network for updated items.
-    case returnFromCacheAndNetwork
-}
-
 /// Retrieves items from persistence or networking and stores them in persistence.
 public final class ItemProvider: Sendable {
     

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -250,10 +250,19 @@ extension ItemProvider: Provider {
                 .eraseToAnyPublisher()
     }
     
+    /// Returns a item or a `ProviderError` after the async operation has been completed.
+    /// - Parameters:
+    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
+    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
+    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
+    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    /// - Returns: The item or error which occurred.
+    ///
+    /// This will use a `fetchPolicy` of `.returnFromCacheElseNetwork` and `allowExpiredItems` of `false` to allow for a single result to be called through a continuation.
     public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<Item, ProviderError> {
         await withCheckedContinuation { continuation in
             var cancellable: AnyCancellable?
-            cancellable = provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { [weak self] result in
+            cancellable = provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork, allowExpiredItem: false) { [weak self] result in
                 continuation.resume(returning: result)
                 
                 cancellable?.cancel()
@@ -264,10 +273,19 @@ extension ItemProvider: Provider {
         }
     }
     
+    /// Returns a collection of items or a `ProviderError` after the async operation has been completed.
+    /// - Parameters:
+    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
+    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
+    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
+    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    /// - Returns: The items or error which occurred.
+    ///
+    /// This will use a `fetchPolicy` of `.returnFromCacheElseNetwork` and `allowExpiredItems` of `false` to allow for a single result to be called through a continuation.
     public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<[Item], ProviderError> {
         await withCheckedContinuation { continuation in
             var cancellable: AnyCancellable?
-            cancellable = provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork) { [weak self] result in
+            cancellable = provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: .returnFromCacheElseNetwork, allowExpiredItems: false) { [weak self] result in
                 continuation.resume(returning: result)
                 
                 cancellable?.cancel()

--- a/Sources/Provider/ProvideItemRequestStateController.swift
+++ b/Sources/Provider/ProvideItemRequestStateController.swift
@@ -110,10 +110,10 @@ public final class ProvideItemRequestStateController<Item: Providable> {
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
-    public func provide(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItem: Bool = false, retryCount: Int = 2) {
+    public func provide(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, allowExpiredItem: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 
-        provider.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
+        provider.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: fetchPolicy, allowExpiredItem: allowExpiredItem)
             .retry(retryCount)
             .mapAsResult()
             .receive(on: scheduler)

--- a/Sources/Provider/ProvideItemRequestStateController.swift
+++ b/Sources/Provider/ProvideItemRequestStateController.swift
@@ -108,6 +108,7 @@ public final class ProvideItemRequestStateController<Item: Providable> {
     ///   - scheduler: The scheduler to receive the result on.
     ///   - providerBehaviors: Additional `ProviderBehavior`s to use.
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
     public func provide(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, allowExpiredItem: Bool = false, retryCount: Int = 2) {

--- a/Sources/Provider/ProvideItemsRequestStateController.swift
+++ b/Sources/Provider/ProvideItemsRequestStateController.swift
@@ -108,6 +108,7 @@ public final class ProvideItemsRequestStateController<Item: Providable> {
     ///   - scheduler: The scheduler to receive the result on.
     ///   - providerBehaviors: Additional `ProviderBehavior`s to use.
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
     public func provideItems(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, allowExpiredItems: Bool = false, retryCount: Int = 2) {

--- a/Sources/Provider/ProvideItemsRequestStateController.swift
+++ b/Sources/Provider/ProvideItemsRequestStateController.swift
@@ -110,10 +110,10 @@ public final class ProvideItemsRequestStateController<Item: Providable> {
     ///   - requestBehaviors: Additional `RequestBehavior`s to append to the request.
     ///   - allowExpiredItem: A `Bool` indicating if the provider should be allowed to return an expired item.
     ///   - retryCount: The number of retries that should be made, if the request failed.
-    public func provideItems(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], allowExpiredItems: Bool = false, retryCount: Int = 2) {
+    public func provideItems(request: any ProviderRequest, decoder: ItemDecoder, scheduler: some Scheduler = DispatchQueue.main, providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], fetchPolicy: FetchPolicy = .returnFromCacheElseNetwork, allowExpiredItems: Bool = false, retryCount: Int = 2) {
         providerStatePublisher.send(.inProgress)
 
-        provider.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: allowExpiredItems)
+        provider.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, fetchPolicy: fetchPolicy, allowExpiredItems: allowExpiredItems)
             .retry(retryCount)
             .mapAsResult()
             .receive(on: scheduler)

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -69,7 +69,7 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    /// - Returns: The item or error which occurred
+    /// - Returns: The item or error which occurred.
     func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<Item, ProviderError>
     
     /// Returns a collection of items or a `ProviderError` after the async operation has been completed.

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -24,10 +24,11 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the item wasn’t successfully retrieved from persistence.
     ///   - handlerQueue: The queue on which to call the `itemHandler`.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     ///   - itemHandler: The closure called upon completing the request that provides the desired item or the error that occurred when attempting to retrieve it.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
+    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, fetchPolicy: FetchPolicy, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
     
     /// Attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success. If `allowExpiredItems` is true, and the expired items exist, the `itemHandler` will first be called with the expired items, and then called again with the result of the network request.
     /// - Parameters:
@@ -36,10 +37,11 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - handlerQueue: The queue on which to call the `itemsHandler`.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If expired items are returned, the completion will be called for both the expired items, and the items retrieved from the network when available.
     ///   - itemsHandler: The closure called upon completing the request that provides the desired items or the error that occurred when attempting to retrieve them.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
+    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, fetchPolicy: FetchPolicy, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success.
     /// - Parameters:
@@ -47,8 +49,9 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItem: Allows the publisher to publish an expired item from the cache. If an expired item is published, this publisher will then also publish an up to date item from the network when it is available.
-    func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItem: Bool) -> AnyPublisher<Item, ProviderError>
+    func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], fetchPolicy: FetchPolicy, allowExpiredItem: Bool) -> AnyPublisher<Item, ProviderError>
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success.
     /// - Parameters:
@@ -56,8 +59,9 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    ///   - fetchPolicy: The policy for how the provider checks the cache and/or the network for items. Defaults to `.returnFromCacheElseNetwork`.
     ///   - allowExpiredItems: Allows the publisher to publish expired items from the cache. If expired items are published, this publisher will then also publish up to date results from the network when they are available.
-    func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
+    func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], fetchPolicy: FetchPolicy, allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
     
     /// Returns a item or a `ProviderError` after the async operation has been completed.
     /// - Parameters:


### PR DESCRIPTION
## What it Does
- Moves `FetchPolicy` off of `ItemProvider` and allows it to be passed in on the provider functions where applicable
- Makes the existing async provide functions only be able to call once to follow the contract of continuation only being able to call once

## How I Tested
- Ran the tests to make sure they continued to pass

## Notes
- There is a bug in the async provides that allow you to have a provider configured with a cache policy that will return from the cache first and then return from the network resulting in the continuation calling twice which is not allowed. This adjusts the API to not allow for that internally so we can maintain the existing default behavior and we will introduce async provides APIs that return an `AsyncStream` instead which will support passing a different fetch policy that could call the result multiple times.
