### PR TITLE
Adds Async Stream Provider Methods

### DIFF
--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -259,22 +259,6 @@ extension ItemProvider: Provider {
                 .eraseToAnyPublisher()
     }
     
-    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<Item, ProviderError> {
-        await withCheckedContinuation { continuation in
-           provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors) { result in
-                continuation.resume(returning: result)
-           }
-        }
-    }
-    
-    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = []) async -> Result<[Item], ProviderError> {
-        await withCheckedContinuation { continuation in
-            provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors) { result in
-                continuation.resume(returning: result)
-            }
-        }
-    }
-    
     public func asyncProvide<Item>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> where Item : Identifiable, Item : Decodable, Item : Encodable {
         return AsyncStream { [weak self] continuation in
             self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: false) { (result: Result<Item, ProviderError>) in
@@ -331,14 +315,6 @@ extension ItemProvider {
     ///   - persistenceURL: The location on disk in which items are persisted. Defaults to the Application Support directory.
     ///   - memoryCacheCapacity: The capacity of the LRU memory cache. Defaults to a limited capacity of 100 items.
     public static func configuredProvider(withRootPersistenceURL persistenceURL: URL = FileManager.default.applicationSupportDirectoryURL, memoryCacheCapacity: CacheCapacity = .limited(numberOfItems: 100), fetchPolicy: ItemProvider.FetchPolicy = .returnFromCacheElseNetwork) -> ItemProvider {
-        let memoryCache = MemoryCache(capacity: memoryCacheCapacity)
-        let diskCache = DiskCache(rootDirectoryURL: persistenceURL)
-        let persister = Persister(memoryCache: memoryCache, diskCache: diskCache)
-        
-        return ItemProvider(networkRequestPerformer: NetworkController(), cache: persister, fetchPolicy: fetchPolicy, defaultProviderBehaviors: [])
-    }
-    
-    public static func configuredStreamingProvider(withRootPersistenceURL persistenceURL: URL = FileManager.default.applicationSupportDirectoryURL, memoryCacheCapacity: CacheCapacity = .limited(numberOfItems: 100), fetchPolicy: ItemProvider.FetchPolicy = .returnFromCacheAndNetwork) -> ItemProvider {
         let memoryCache = MemoryCache(capacity: memoryCacheCapacity)
         let diskCache = DiskCache(rootDirectoryURL: persistenceURL)
         let persister = Persister(memoryCache: memoryCache, diskCache: diskCache)

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -97,6 +97,7 @@ extension ItemProvider: Provider {
     }
     
     @discardableResult public func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable? {
+        
         var cancellable: AnyCancellable?
         cancellable = provideItems(request: request,
                      decoder: decoder,

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -96,7 +96,7 @@ extension ItemProvider: Provider {
         return cancellable
     }
     
-    @discardableResult public func provideItems<Item>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)? = nil) -> AnyCancellable? where Item : Identifiable, Item : Decodable, Item : Encodable {
+    @discardableResult public func provideItems<Item>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)? = nil) -> AnyCancellable? where Item : Identifiable, Item : Decodable, Item : Encodable {
         var cancellable: AnyCancellable?
         cancellable = provideItems(request: request,
                      decoder: decoder,

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -271,12 +271,11 @@ extension ItemProvider: Provider {
                         continuation.yield(.failure(error))
                     }
                     continuation.finish()
-                    self?.removeCancellable(cancellable: cancellable)
+                    cancellable?.cancel()
                     cancellable = nil
                 } receiveValue: { item in
                     continuation.yield(.success(item))
                 }
-            self?.insertCancellable(cancellable: cancellable)
         }
     }
     
@@ -291,12 +290,11 @@ extension ItemProvider: Provider {
                     case .finished: break
                     }
                     continuation.finish()
-                    self?.removeCancellable(cancellable: cancellable)
+                    cancellable?.cancel()
                     cancellable = nil
                 } receiveValue: { items in
                     continuation.yield(.success(items))
                 }
-            self?.insertCancellable(cancellable: cancellable)
         }
     }
     

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -85,6 +85,7 @@ extension ItemProvider: Provider {
                 case .finished:
                     break
                 }
+                
                 self?.removeCancellable(cancellable: cancellable)
             }, receiveValue: { (item: Item) in
                 itemHandler(.success(item))
@@ -110,6 +111,7 @@ extension ItemProvider: Provider {
                 case .finished:
                     break
                 }
+                
                 self?.removeCancellable(cancellable: cancellable)
             }, receiveValue: { (items: [Item]) in
                 itemsHandler(.success(items))
@@ -258,8 +260,8 @@ extension ItemProvider: Provider {
     }
     
     public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> {
-        var cancellable: AnyCancellable?
         return AsyncStream { [weak self] continuation in
+            var cancellable: AnyCancellable?
             cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: false)
                 .sink { completion in
                     switch completion {
@@ -268,6 +270,8 @@ extension ItemProvider: Provider {
                         continuation.yield(.failure(error))
                     }
                     continuation.finish()
+                    self?.removeCancellable(cancellable: cancellable)
+                    cancellable = nil
                 } receiveValue: { item in
                     continuation.yield(.success(item))
                 }
@@ -276,8 +280,8 @@ extension ItemProvider: Provider {
     }
     
     public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<[Item], ProviderError>> {
-        var cancellable: AnyCancellable?
         return AsyncStream { [weak self] continuation in
+            var cancellable: AnyCancellable?
             cancellable =  self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false)
                 .sink { completion in
                     switch completion {
@@ -286,6 +290,8 @@ extension ItemProvider: Provider {
                     case .finished: break
                     }
                     continuation.finish()
+                    self?.removeCancellable(cancellable: cancellable)
+                    cancellable = nil
                 } receiveValue: { items in
                     continuation.yield(.success(items))
                 }

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -260,11 +260,10 @@ extension ItemProvider: Provider {
                 .eraseToAnyPublisher()
     }
     
-    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItem: Bool = false) async -> AsyncStream<Result<Item, ProviderError>> {
+    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], allowExpiredItem: Bool = false) async -> AsyncStream<Result<Item, ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
             cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
-                .receive(on: handlerQueue)
                 .sink { completion in
                     switch completion {
                     case .finished: break
@@ -281,11 +280,10 @@ extension ItemProvider: Provider {
         }
     }
     
-    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false) async -> AsyncStream<Result<[Item], ProviderError>> {
+    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], allowExpiredItems: Bool = false) async -> AsyncStream<Result<[Item], ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
             cancellable =  self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false)
-                .receive(on: handlerQueue)
                 .sink { completion in
                     switch completion {
                     case let .failure(error):

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -96,7 +96,7 @@ extension ItemProvider: Provider {
         return cancellable
     }
     
-    @discardableResult public func provideItems<Item>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)? = nil) -> AnyCancellable? where Item : Identifiable, Item : Decodable, Item : Encodable {
+    @discardableResult public func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [ProviderBehavior] = [], requestBehaviors: [RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)? = nil) -> AnyCancellable? {
         var cancellable: AnyCancellable?
         cancellable = provideItems(request: request,
                      decoder: decoder,
@@ -259,7 +259,7 @@ extension ItemProvider: Provider {
                 .eraseToAnyPublisher()
     }
     
-    public func asyncProvide<Item>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> where Item : Identifiable, Item : Decodable, Item : Encodable {
+    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> {
         return AsyncStream { [weak self] continuation in
             self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: false) { (result: Result<Item, ProviderError>) in
                 continuation.yield(result)
@@ -269,7 +269,7 @@ extension ItemProvider: Provider {
         }
     }
     
-    public func asyncProvideItems<Item>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<[Item], ProviderError>> where Item : Identifiable, Item : Decodable, Item : Encodable {
+    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<[Item], ProviderError>> {
         return AsyncStream { [weak self] continuation in
             self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false) { (result: Result<[Item], ProviderError>) in
                 continuation.yield(result)

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -259,10 +259,11 @@ extension ItemProvider: Provider {
                 .eraseToAnyPublisher()
     }
     
-    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> {
+    public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItem: Bool = false) async -> AsyncStream<Result<Item, ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
-            cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: false)
+            cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
+                .receive(on: handlerQueue)
                 .sink { completion in
                     switch completion {
                     case .finished: break
@@ -279,10 +280,11 @@ extension ItemProvider: Provider {
         }
     }
     
-    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<[Item], ProviderError>> {
+    public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], handlerQueue: DispatchQueue = .main, allowExpiredItems: Bool = false) async -> AsyncStream<Result<[Item], ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
             cancellable =  self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false)
+                .receive(on: handlerQueue)
                 .sink { completion in
                     switch completion {
                     case let .failure(error):

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -279,12 +279,7 @@ extension ItemProvider: Provider {
     public func asyncProvide<Item>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<Item, ProviderError>> where Item : Identifiable, Item : Decodable, Item : Encodable {
         return AsyncStream { [weak self] continuation in
             self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: false) { (result: Result<Item, ProviderError>) in
-                switch result {
-                case let .success(item):
-                    continuation.yield(.success(item))
-                case let .failure(error):
-                    continuation.yield(.failure(error))
-                }
+                continuation.yield(result)
                 continuation.finish()
             }
         }
@@ -293,12 +288,7 @@ extension ItemProvider: Provider {
     public func asyncProvideItems<Item>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = []) async -> AsyncStream<Result<[Item], ProviderError>> where Item : Identifiable, Item : Decodable, Item : Encodable {
         return AsyncStream { [weak self] continuation in
             self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false) { (result: Result<[Item], ProviderError>) in
-                switch result {
-                case let .success(items):
-                    continuation.yield(.success(items))
-                case .failure(let error):
-                    continuation.yield(.failure(error))
-                }
+                continuation.yield(result)
                 continuation.finish()
             }
         }

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -263,7 +263,7 @@ extension ItemProvider: Provider {
     public func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: any ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], allowExpiredItem: Bool = false) async -> AsyncStream<Result<Item, ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
-            cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
+            cancellable = self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
                 .sink { completion in
                     switch completion {
                     case .finished: break
@@ -282,7 +282,7 @@ extension ItemProvider: Provider {
     public func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder = JSONDecoder(), providerBehaviors: [any ProviderBehavior] = [], requestBehaviors: [any Networking.RequestBehavior] = [], allowExpiredItems: Bool = false) async -> AsyncStream<Result<[Item], ProviderError>> {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
-            cancellable =  self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false)
+            cancellable = self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: allowExpiredItems)
                 .sink { completion in
                     switch completion {
                     case let .failure(error):

--- a/Sources/Provider/ItemProvider.swift
+++ b/Sources/Provider/ItemProvider.swift
@@ -264,15 +264,8 @@ extension ItemProvider: Provider {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
             cancellable =  self?.provide(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItem: allowExpiredItem)
-                .sink { completion in
-                    switch completion {
-                    case .finished: break
-                    case let .failure(error):
-                        continuation.yield(.failure(error))
-                    }
-                    continuation.finish()
-                    cancellable?.cancel()
-                    cancellable = nil
+                .sink { [weak self] completion in
+                    self?.handlePublisherCompletion(completion: completion, continuation: continuation, cancellable: &cancellable)
                 } receiveValue: { item in
                     continuation.yield(.success(item))
                 }
@@ -283,15 +276,8 @@ extension ItemProvider: Provider {
         return AsyncStream { [weak self] continuation in
             var cancellable: AnyCancellable?
             cancellable =  self?.provideItems(request: request, decoder: decoder, providerBehaviors: providerBehaviors, requestBehaviors: requestBehaviors, allowExpiredItems: false)
-                .sink { completion in
-                    switch completion {
-                    case let .failure(error):
-                        continuation.yield(.failure(error))
-                    case .finished: break
-                    }
-                    continuation.finish()
-                    cancellable?.cancel()
-                    cancellable = nil
+                .sink { [weak self] completion in
+                    self?.handlePublisherCompletion(completion: completion, continuation: continuation, cancellable: &cancellable)
                 } receiveValue: { items in
                     continuation.yield(.success(items))
                 }
@@ -324,6 +310,17 @@ extension ItemProvider: Provider {
                 }
             })
             .eraseToAnyPublisher()
+    }
+    
+    private func handlePublisherCompletion<T>(completion: Subscribers.Completion<ProviderError>, continuation: AsyncStream<Result<T, ProviderError>>.Continuation, cancellable: inout AnyCancellable?) {
+        switch completion {
+        case let .failure(error):
+            continuation.yield(.failure(error))
+        case .finished: break
+        }
+        continuation.finish()
+        cancellable?.cancel()
+        cancellable = nil
     }
 }
 

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -79,16 +79,16 @@ public protocol Provider: Sendable {
     /// - Returns: The items or error which occurred.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<[Item], ProviderError>
     
-    /// Returns a stream of a single item. Completes after an error or item is emitted.
+    /// Returns a stream of a single item.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    /// - Returns: An async throwing steam which emits an item or an error.
+    /// - Returns: An async steam which emits an item or an error.
     func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async  -> AsyncStream<Result<Item, ProviderError>>
     
-    /// Returns a stream of items. Completes after an error or items is emitted.
+    /// Returns a stream of items.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -65,10 +65,9 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    ///   - handlerQueue: The queue on which to receive the network response on.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits an item or an error.
-    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool) async -> AsyncStream<Result<Item, ProviderError>>
+    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItem: Bool) async -> AsyncStream<Result<Item, ProviderError>>
     
     /// Returns a stream of items.
     /// - Parameters:
@@ -76,8 +75,7 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    ///   - handlerQueue: The queue on which to receive the network response on.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits a collection of items or an error.
-    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool) async -> AsyncStream<Result<[Item], ProviderError>>
+    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -26,8 +26,9 @@ public protocol Provider: Sendable {
     ///   - handlerQueue: The queue on which to call the `itemHandler`.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     ///   - itemHandler: The closure called upon completing the request that provides the desired item or the error that occurred when attempting to retrieve it.
+    ///   - completionHandler: Called when there is an error or the publisher completion finishes.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
+    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void, completionHandler: (() -> Void)?) -> AnyCancellable?
     
     /// Attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success. If `allowExpiredItems` is true, and the expired items exist, the `itemHandler` will first be called with the expired items, and then called again with the result of the network request.
     /// - Parameters:
@@ -38,8 +39,9 @@ public protocol Provider: Sendable {
     ///   - handlerQueue: The queue on which to call the `itemsHandler`.
     ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If expired items are returned, the completion will be called for both the expired items, and the items retrieved from the network when available.
     ///   - itemsHandler: The closure called upon completing the request that provides the desired items or the error that occurred when attempting to retrieve them.
+    ///   - completionHandler: Called when there is an error or the publisher completion finishes.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
+    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)?) -> AnyCancellable?
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success.
     /// - Parameters:

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -77,7 +77,7 @@ public protocol Provider: Sendable {
     /// - Returns: The items or error which occurred.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<[Item], ProviderError>
     
-    /// Returns a stream of a single item. If an error is thrown the error is thrown to the user.
+    /// Returns a stream of a single item. Completes after an error or item is emitted.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
@@ -86,12 +86,12 @@ public protocol Provider: Sendable {
     /// - Returns: An async throwing steam which emits an item or an error.
     func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async  -> AsyncStream<Result<Item, ProviderError>>
     
-    /// Returns a stream of items. If an error is thrown the error is thrown to the user.
+    /// Returns a stream of items. Completes after an error or items is emitted.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    /// - Returns: An async throwing steam which emits a collection of items or an error.
+    /// - Returns: An async steam which emits a collection of items or an error.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -61,24 +61,6 @@ public protocol Provider: Sendable {
     ///   - allowExpiredItems: Allows the publisher to publish expired items from the cache. If expired items are published, this publisher will then also publish up to date results from the network when they are available.
     func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
     
-    /// Returns a item or a `ProviderError` after the async operation has been completed.
-    /// - Parameters:
-    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
-    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
-    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
-    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    /// - Returns: The item or error which occurred
-    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<Item, ProviderError>
-    
-    /// Returns a collection of items or a `ProviderError` after the async operation has been completed.
-    /// - Parameters:
-    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
-    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
-    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
-    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    /// - Returns: The items or error which occurred.
-    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<[Item], ProviderError>
-    
     /// Returns a stream of a single item.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -26,9 +26,8 @@ public protocol Provider: Sendable {
     ///   - handlerQueue: The queue on which to call the `itemHandler`.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     ///   - itemHandler: The closure called upon completing the request that provides the desired item or the error that occurred when attempting to retrieve it.
-    ///   - completionHandler: Called when there is an error or the publisher completion finishes.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void, completionHandler: (() -> Void)?) -> AnyCancellable?
+    @discardableResult func provide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool, itemHandler: @escaping (Result<Item, ProviderError>) -> Void) -> AnyCancellable?
     
     /// Attempts to retrieve an array of items using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the items will be persisted upon success. If `allowExpiredItems` is true, and the expired items exist, the `itemHandler` will first be called with the expired items, and then called again with the result of the network request.
     /// - Parameters:
@@ -39,9 +38,8 @@ public protocol Provider: Sendable {
     ///   - handlerQueue: The queue on which to call the `itemsHandler`.
     ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If expired items are returned, the completion will be called for both the expired items, and the items retrieved from the network when available.
     ///   - itemsHandler: The closure called upon completing the request that provides the desired items or the error that occurred when attempting to retrieve them.
-    ///   - completionHandler: Called when there is an error or the publisher completion finishes.
     /// - Returns: Returns a `AnyCancellable` that lets you cancel the request.
-    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void, completionHandler: (() -> Void)?) -> AnyCancellable?
+    @discardableResult func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool, itemsHandler: @escaping (Result<[Item], ProviderError>) -> Void) -> AnyCancellable?
     
     /// Produces a publisher which, when subscribed to, attempts to retrieve an item using the provided request, checking persistence first where possible and falling back to the network. If the network is used, the item will be persisted upon success.
     /// - Parameters:

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -76,4 +76,22 @@ public protocol Provider: Sendable {
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     /// - Returns: The items or error which occurred.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> Result<[Item], ProviderError>
+    
+    /// Returns a stream of a single item. If an error is thrown the error is thrown to the user.
+    /// - Parameters:
+    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
+    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
+    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
+    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    /// - Returns: An async throwing steam which emits an item or an error.
+    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncThrowingStream<Item, any Error>
+    
+    /// Returns a stream of items. If an error is thrown the error is thrown to the user.
+    /// - Parameters:
+    ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
+    ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
+    ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
+    ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    /// - Returns: An async throwing steam which emits a collection of items or an error.
+    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncThrowingStream<[Item], any Error>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -84,7 +84,7 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     /// - Returns: An async throwing steam which emits an item or an error.
-    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncThrowingStream<Item, any Error>
+    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async  -> AsyncStream<Result<Item, ProviderError>>
     
     /// Returns a stream of items. If an error is thrown the error is thrown to the user.
     /// - Parameters:
@@ -93,5 +93,5 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     /// - Returns: An async throwing steam which emits a collection of items or an error.
-    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncThrowingStream<[Item], any Error>
+    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -66,7 +66,7 @@ public protocol Provider: Sendable {
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     /// - Returns: An async steam which emits an item or an error.
-    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async  -> AsyncStream<Result<Item, ProviderError>>
+    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncStream<Result<Item, ProviderError>>
     
     /// Returns a stream of items.
     /// - Parameters:

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -59,17 +59,19 @@ public protocol Provider: Sendable {
     ///   - allowExpiredItems: Allows the publisher to publish expired items from the cache. If expired items are published, this publisher will then also publish up to date results from the network when they are available.
     func provideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) -> AnyPublisher<[Item], ProviderError>
     
-    /// Returns a stream of a single item.
+    /// Makes a request for an item and provides the result of that request as a stream of results.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
-    /// - Returns: An async steam which emits an item or an error.
+    /// - Returns: An async steam which emits results of the item or error.
+    ///
+    /// This stream can call multiple times depending on the `FetchPolicy` when you have it configured on a `ItemProvider`. Depending on the configured policy, it could return a single time with just the item or an error. It also can be configured to return a cache item first, then request from the network and return either the resulting network item or an error.
     func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItem: Bool) async -> AsyncStream<Result<Item, ProviderError>>
     
-    /// Returns a stream of items.
+    /// Makes a request for a collection of items and provides the result of that request as a stream of results.
     /// - Parameters:
     ///   - request: The request that provides the details needed to retrieve the items from persistence or networking.
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
@@ -77,5 +79,7 @@ public protocol Provider: Sendable {
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
     ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits a collection of items or an error.
+    ///
+    /// This stream can call multiple times depending on the `FetchPolicy` when you have it configured on a `ItemProvider`. Depending on the configured policy, it could return a single time with a collection of items or an error. It also can be configured to return a collection of items first, then request from the network and return either the resulting network a collection of items or an error.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -65,8 +65,10 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    ///   - handlerQueue: The queue on which to receive the network response on.
+    ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits an item or an error.
-    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncStream<Result<Item, ProviderError>>
+    func asyncProvide<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItem: Bool) async -> AsyncStream<Result<Item, ProviderError>>
     
     /// Returns a stream of items.
     /// - Parameters:
@@ -74,6 +76,8 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
+    ///   - handlerQueue: The queue on which to receive the network response on.
+    ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits a collection of items or an error.
-    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior]) async -> AsyncStream<Result<[Item], ProviderError>>
+    func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], handlerQueue: DispatchQueue, allowExpiredItems: Bool) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Sources/Provider/Provider.swift
+++ b/Sources/Provider/Provider.swift
@@ -75,7 +75,7 @@ public protocol Provider: Sendable {
     ///   - decoder: The decoder used to convert network response data into an array of the type specified by the generic placeholder.
     ///   - providerBehaviors: Actions to perform before the provider request is performed and / or after the provider request is completed.
     ///   - requestBehaviors: Actions to perform before the network request is performed and / or after the network request is completed. Only called if the items weren’t successfully retrieved from persistence.
-    ///   - allowExpiredItem: Allows the provider to return an expired item from the cache. If an expired item is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
+    ///   - allowExpiredItems: Allows the provider to return expired items from the cache. If an expired items is returned, the completion will be called for both the expired item, and the item retrieved from the network when available.
     /// - Returns: An async steam which emits a collection of items or an error.
     func asyncProvideItems<Item: Providable>(request: any ProviderRequest, decoder: ItemDecoder, providerBehaviors: [ProviderBehavior], requestBehaviors: [RequestBehavior], allowExpiredItems: Bool) async -> AsyncStream<Result<[Item], ProviderError>>
 }

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -113,7 +113,7 @@ final class ItemProviderTests_Async: XCTestCase {
     
     // MARK: - Async Provide Item Async Stream Tests
     
-    func testProvideItemStream() async {
+    func testProvideItem() async {
         let request = TestProviderRequest()
         
         stub(condition: { _ in true }) { _ in
@@ -131,7 +131,7 @@ final class ItemProviderTests_Async: XCTestCase {
         }
     }
     
-    func testProvideItemReturnsCachedResultStream() async {
+    func testProvideItemReturnsCachedResult() async {
         let request = TestProviderRequest()
         
         let originalStub = stub(condition: { _ in true }) { _ in

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -39,212 +39,6 @@ final class ItemProviderTests_Async: XCTestCase {
         try? expiredProvider.cache?.removeAll()
     }
     
-    // MARK: - Async Provide Items Tests
-    
-    func testProvideItems() async {
-        let request = TestProviderRequest()
-        
-        stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.itemsPath, headers: nil)
-        }
-        
-        let result: Result<[TestItem], ProviderError> = await provider.asyncProvideItems(request: request)
-        
-        switch result {
-        case let .success(items):
-            XCTAssertEqual(items.count, 3)
-        case let .failure(error):
-            XCTFail("There should be no error: \(error)")
-        }
-    }
-    
-    func testProvideItemsReturnsPartialResponseUponFailure() async {
-        let request = TestProviderRequest()
-        
-        let originalStub = stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.itemsPath, headers: nil)
-        }
-
-        let _ : Result<[TestItem], ProviderError> = await provider.asyncProvideItems(request: request)
-        
-        try? self.provider.cache?.remove(forKey: "Hello 2")
-        HTTPStubs.removeStub(originalStub)
-        
-        stub(condition: { _ in true}) { _ in
-            fixture(filePath: self.itemPath, headers: nil)
-        }
-        
-        let secondResult: Result<[TestItem], ProviderError> = await provider.asyncProvideItems(request: request)
-       
-        switch secondResult {
-        case .success:
-            XCTFail("Should have received a partial retrieval failure.")
-        case let .failure(error):
-            switch error {
-            case let .partialRetrieval(retrievedItems, persistenceErrors, error):
-                let expectedItemIDs = ["Hello 1", "Hello 3"]
-                
-                XCTAssertEqual(retrievedItems.map { $0.identifier }, expectedItemIDs)
-                XCTAssertEqual(persistenceErrors.count, 1)
-                XCTAssertEqual(persistenceErrors.first?.key, "Hello 2")
-                
-                guard case ProviderError.decodingError = error else {
-                    XCTFail("Incorrect error received.")
-                    return
-                }
-                
-                guard let persistenceError = persistenceErrors.first?.persistenceError, case PersistenceError.noValidDataForKey = persistenceError else {
-                    XCTFail("Incorrect error received.")
-                    return
-                }
-                
-            default: XCTFail("Should have received a partial retrieval error.")
-            }
-        }
-    }
-    
-    func testProvideItemsDoesNotReturnPartialResponseUponFailureForExpiredItems() async {
-        let request = TestProviderRequest()
-        
-        let originalStub = stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.itemsPath, headers: nil)
-        }
-        
-        let _ : Result<[TestItem], ProviderError> = await expiredProvider.asyncProvideItems(request: request)
-        
-        try? self.expiredProvider.cache?.remove(forKey: "Hello 2")
-        HTTPStubs.removeStub(originalStub)
-        
-        stub(condition: { _ in true}) { _ in
-            fixture(filePath: self.itemPath, headers: nil)
-        }
-        
-        let expiredResult : Result<[TestItem], ProviderError> = await expiredProvider.asyncProvideItems(request: request)
-        
-        switch expiredResult {
-        case .success:
-            XCTFail("Should have received a decoding error.")
-        case let .failure(error):
-            switch error {
-            case .decodingError: break
-            default: XCTFail("Should have received a decoding error.")
-            }
-        }
-    }
-    
-    func testProvideItemsFailure() async {
-        let request = TestProviderRequest()
-        
-        stub(condition: { _ in true }) { _ in
-            fixture(filePath: OHPathForFile("InvalidItems.json", type(of: self))!, headers: nil)
-        }
-        
-        let result : Result<[TestItem], ProviderError> = await provider.asyncProvideItems(request: request)
-        switch result {
-        case .success:
-            XCTFail("There should be an error.")
-        case .failure: break
-        }
-    }
-    
-    // MARK: - Async Provide Item Tests
-    
-    func testProvideItem() async {
-        let request = TestProviderRequest()
-        
-        stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.itemPath, headers: nil)
-        }
-        
-        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
-        
-        switch result {
-        case .success: break
-        case let .failure(error):
-            XCTFail("There should be no error: \(error)")
-        }
-    }
-    
-    func testProvideItemReturnsCachedResult() async {
-        let request = TestProviderRequest()
-        
-        let originalStub = stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.itemPath, headers: nil)
-        }
-        
-        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
-        
-        switch result {
-        case .success:
-            HTTPStubs.removeStub(originalStub)
-            
-            stub(condition: { _ in true }) { _ in
-                fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
-            }
-            
-            let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
-            switch result {
-            case .success:
-                break
-            case let .failure(error):
-                XCTFail("There should be no error: \(error)")
-            }
-            
-        case let .failure(error):
-            XCTFail("There should be no error: \(error)")
-        }
-    }
-    
-    func testProvideItemFailure() async {
-        let request = TestProviderRequest()
-    
-        stub(condition: { _ in true }) { _ in
-            fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
-        }
-        
-        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
-        switch result {
-        case .success:
-            XCTFail("There should be an error.")
-        case .failure: break
-        }
-    }
-    
-    func testAsyncProvideItemsWithCustomDecoder() async {
-        let request = TestProviderRequest()
-        
-        stub(condition: { _ in true }) { _ in
-            fixture(filePath: self.datesPath, headers: nil)
-        }
-        
-        // Test first to ensure failure when not providing a custom decoder.
-        let result1: Result<[TestDateContainer], ProviderError> = await provider.asyncProvideItems(request: request)
-        
-        switch result1 {
-        case .success:
-            XCTFail("Decoding should fail due to incorrect date format")
-        case let .failure(error):
-            switch error {
-            case .decodingError:
-                break
-            default:
-                XCTFail("An unexpected, non-decoding error occurred: \(error)")
-            }
-        }
-        
-        // Now test the same file with our custom decoder.
-        let customDecoder = JSONDecoder()
-        customDecoder.dateDecodingStrategy = .iso8601
-        let result2: Result<[TestDateContainer], ProviderError> = await provider.asyncProvideItems(request: request, decoder: customDecoder)
-        
-        switch result2 {
-        case let .success(dateContainers):
-            XCTAssertEqual(dateContainers.count, 2)
-        case let .failure(error):
-            XCTFail("An unexpected error occurred: \(error)")
-        }
-    }
-    
     // MARK: - Async Provide Items Async Stream Tests
     
     func testProvideItemsStream() async {
@@ -341,28 +135,30 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemPath, headers: nil)
         }
         
-        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
         
-        switch result {
-        case .success:
-            HTTPStubs.removeStub(originalStub)
-            
-            stub(condition: { _ in true }) { _ in
-                fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
-            }
-            
-            let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
-            for await result in result {
-                switch result {
-                case .success:
-                    break
-                case let .failure(error):
-                    XCTFail("There should be no error: \(error)")
+        for await result in result {
+            switch result {
+            case .success:
+                HTTPStubs.removeStub(originalStub)
+                
+                stub(condition: { _ in true }) { _ in
+                    fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
                 }
+                
+                let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+                for await result in result {
+                    switch result {
+                    case .success:
+                        break
+                    case let .failure(error):
+                        XCTFail("There should be no error: \(error)")
+                    }
+                }
+                
+            case let .failure(error):
+                XCTFail("There should be no error: \(error)")
             }
-            
-        case let .failure(error):
-            XCTFail("There should be no error: \(error)")
         }
     }
     

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -243,4 +243,143 @@ final class ItemProviderTests_Async: XCTestCase {
             XCTFail("An unexpected error occurred: \(error)")
         }
     }
+    
+    // MARK: - Async Provide Items Async Stream Tests
+    
+    func testProvideItemsStream() async {
+        let request = TestProviderRequest()
+        
+        stub(condition: { _ in true }) { _ in
+            fixture(filePath: self.itemsPath, headers: nil)
+        }
+        
+        let testItemResult: AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request, decoder: JSONDecoder(), providerBehaviors: [], requestBehaviors: [])
+        for try await result in testItemResult {
+            switch result {
+            case let .success(testItems):
+                XCTAssertEqual(testItems.count, 3)
+            case let .failure(error):
+                XCTFail("There should be no error: \(error)")
+            }
+          
+        }
+    }
+    
+    func testProvideItemsDoesNotReturnPartialResponseUponFailureForExpiredItemsStream() async {
+        let request = TestProviderRequest()
+        
+        let originalStub = stub(condition: { _ in true }) { _ in
+            fixture(filePath: self.itemsPath, headers: nil)
+        }
+        
+        let _ : AsyncStream<Result<[TestItem], ProviderError>> = await expiredProvider.asyncProvideItems(request: request)
+        
+        try? self.expiredProvider.cache?.remove(forKey: "Hello 2")
+        HTTPStubs.removeStub(originalStub)
+        
+        stub(condition: { _ in true}) { _ in
+            fixture(filePath: self.itemPath, headers: nil)
+        }
+        
+        let expiredResult : AsyncStream<Result<[TestItem], ProviderError>> = await expiredProvider.asyncProvideItems(request: request)
+        
+        for await result in expiredResult {
+            switch result {
+            case .success:
+                XCTFail("Should have received a decoding error.")
+            case let .failure(error):
+                switch error {
+                case .decodingError: break
+                default: XCTFail("Should have received a decoding error.")
+                }
+            }
+        }
+    }
+    
+    func testProvideItemsFailureStream() async {
+        let request = TestProviderRequest()
+        
+        stub(condition: { _ in true }) { _ in
+            fixture(filePath: OHPathForFile("InvalidItems.json", type(of: self))!, headers: nil)
+        }
+        
+        let result : AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request)
+        for await result in result {
+            switch result {
+            case .success:
+                XCTFail("There should be an error.")
+            case .failure: break
+            }
+        }
+    }
+    
+    // MARK: - Async Provide Item Async Stream Tests
+    
+    func testProvideItemStream() async {
+        let request = TestProviderRequest()
+        
+        stub(condition: { _ in true }) { _ in
+            fixture(filePath: self.itemPath, headers: nil)
+        }
+        
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+        
+        for await result in result {
+            switch result {
+            case .success: break
+            case let .failure(error):
+                XCTFail("There should be no error: \(error)")
+            }
+        }
+    }
+    
+    func testProvideItemReturnsCachedResultStream() async {
+        let request = TestProviderRequest()
+        
+        let originalStub = stub(condition: { _ in true }) { _ in
+            fixture(filePath: self.itemPath, headers: nil)
+        }
+        
+        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
+        
+        switch result {
+        case .success:
+            HTTPStubs.removeStub(originalStub)
+            
+            stub(condition: { _ in true }) { _ in
+                fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
+            }
+            
+            let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+            for await result in result {
+                switch result {
+                case .success:
+                    break
+                case let .failure(error):
+                    XCTFail("There should be no error: \(error)")
+                }
+            }
+            
+        case let .failure(error):
+            XCTFail("There should be no error: \(error)")
+        }
+    }
+    
+    func testProvideItemFailureStream() async {
+        let request = TestProviderRequest()
+        
+        stub(condition: { _ in true }) { _ in
+            fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
+        }
+        
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+        
+        for await result in result {
+            switch result {
+            case .success:
+                XCTFail("There should be an error.")
+            case .failure: break
+            }
+        }
+    }
 }

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -20,8 +20,7 @@ import Persister
 final class ItemProviderTests_Async: XCTestCase {
 
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
-    private let asyncStreamProvider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
-    
+
     private let expiredProvider: ItemProvider = {
         let networkController = NetworkController()
         let cache = Persister(memoryCache: MemoryCache(capacity: .unlimited, expirationPolicy: .afterInterval(-1)), diskCache: DiskCache(rootDirectoryURL: FileManager.default.cachesDirectoryURL, expirationPolicy: .afterInterval(-1)))
@@ -255,7 +254,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemsPath, headers: nil)
         }
         
-        let testItemResult: AsyncStream<Result<[TestItem], ProviderError>> = await asyncStreamProvider.asyncProvideItems(request: request, decoder: JSONDecoder(), providerBehaviors: [], requestBehaviors: [])
+        let testItemResult: AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request, decoder: JSONDecoder(), providerBehaviors: [], requestBehaviors: [])
         for try await result in testItemResult {
             switch result {
             case let .success(testItems):
@@ -305,7 +304,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: OHPathForFile("InvalidItems.json", type(of: self))!, headers: nil)
         }
         
-        let result : AsyncStream<Result<[TestItem], ProviderError>> = await asyncStreamProvider.asyncProvideItems(request: request)
+        let result : AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request)
         for await result in result {
             switch result {
             case .success:
@@ -324,7 +323,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemPath, headers: nil)
         }
         
-        let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
         
         for await result in result {
             switch result {
@@ -342,7 +341,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemPath, headers: nil)
         }
         
-        let result: Result<TestItem, ProviderError> = await asyncStreamProvider.asyncProvide(request: request)
+        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
         
         switch result {
         case .success:
@@ -352,7 +351,7 @@ final class ItemProviderTests_Async: XCTestCase {
                 fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
             }
             
-            let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
+            let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
             for await result in result {
                 switch result {
                 case .success:
@@ -374,7 +373,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
         }
         
-        let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
         
         for await result in result {
             switch result {

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -20,6 +20,8 @@ import Persister
 final class ItemProviderTests_Async: XCTestCase {
 
     private let provider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
+    private let asyncStreamProvider = ItemProvider.configuredProvider(withRootPersistenceURL: FileManager.default.cachesDirectoryURL, memoryCacheCapacity: .unlimited)
+    
     private let expiredProvider: ItemProvider = {
         let networkController = NetworkController()
         let cache = Persister(memoryCache: MemoryCache(capacity: .unlimited, expirationPolicy: .afterInterval(-1)), diskCache: DiskCache(rootDirectoryURL: FileManager.default.cachesDirectoryURL, expirationPolicy: .afterInterval(-1)))
@@ -253,7 +255,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemsPath, headers: nil)
         }
         
-        let testItemResult: AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request, decoder: JSONDecoder(), providerBehaviors: [], requestBehaviors: [])
+        let testItemResult: AsyncStream<Result<[TestItem], ProviderError>> = await asyncStreamProvider.asyncProvideItems(request: request, decoder: JSONDecoder(), providerBehaviors: [], requestBehaviors: [])
         for try await result in testItemResult {
             switch result {
             case let .success(testItems):
@@ -303,7 +305,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: OHPathForFile("InvalidItems.json", type(of: self))!, headers: nil)
         }
         
-        let result : AsyncStream<Result<[TestItem], ProviderError>> = await provider.asyncProvideItems(request: request)
+        let result : AsyncStream<Result<[TestItem], ProviderError>> = await asyncStreamProvider.asyncProvideItems(request: request)
         for await result in result {
             switch result {
             case .success:
@@ -322,7 +324,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemPath, headers: nil)
         }
         
-        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
         
         for await result in result {
             switch result {
@@ -340,7 +342,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: self.itemPath, headers: nil)
         }
         
-        let result: Result<TestItem, ProviderError> = await provider.asyncProvide(request: request)
+        let result: Result<TestItem, ProviderError> = await asyncStreamProvider.asyncProvide(request: request)
         
         switch result {
         case .success:
@@ -350,7 +352,7 @@ final class ItemProviderTests_Async: XCTestCase {
                 fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
             }
             
-            let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+            let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
             for await result in result {
                 switch result {
                 case .success:
@@ -372,7 +374,7 @@ final class ItemProviderTests_Async: XCTestCase {
             fixture(filePath: OHPathForFile("InvalidItem.json", type(of: self))!, headers: nil)
         }
         
-        let result: AsyncStream<Result<TestItem, ProviderError>> = await provider.asyncProvide(request: request)
+        let result: AsyncStream<Result<TestItem, ProviderError>> = await asyncStreamProvider.asyncProvide(request: request)
         
         for await result in result {
             switch result {

--- a/Tests/ItemProviderTest+Async.swift
+++ b/Tests/ItemProviderTest+Async.swift
@@ -89,7 +89,8 @@ final class ItemProviderTests_Async: XCTestCase {
                     switch error {
                     case .decodingError:
                        break
-                    default: XCTFail("Should have received a decoding error.")
+                    case .networkError, .partialRetrieval, .persistenceError:
+                        XCTFail("Should have received a decoding error, but found \(error)")
                     }
                 }
             }
@@ -138,7 +139,7 @@ final class ItemProviderTests_Async: XCTestCase {
                             XCTFail("Incorrect error received.")
                             return
                         }
-                    default:
+                    case .networkError, .decodingError, .persistenceError:
                         XCTFail("Should have received a partial retrieval error. But got \(error)")
                     }
                 }
@@ -162,7 +163,7 @@ final class ItemProviderTests_Async: XCTestCase {
             case let .failure(error):
                 switch error {
                 case .networkError, .partialRetrieval, .persistenceError:
-                    XCTFail("Expected decoding error.")
+                    XCTFail("Expected decoding error but found \(error)")
                 case .decodingError:
                     break
                 }
@@ -188,8 +189,8 @@ final class ItemProviderTests_Async: XCTestCase {
                 switch error {
                 case .decodingError:
                     break
-                default:
-                    XCTFail("An unexpected, non-decoding error occurred: \(error)")
+                case .networkError, .partialRetrieval, .persistenceError:
+                    XCTFail("Expected decoding error but found \(error)")
                 }
             }
         }
@@ -304,7 +305,7 @@ final class ItemProviderTests_Async: XCTestCase {
             case let .failure(error):
                 switch error {
                 case .networkError, .partialRetrieval, .persistenceError:
-                    XCTFail("Expected decoding error.")
+                    XCTFail("Expected decoding error but found \(error)")
                 case .decodingError:
                     break
                 }
@@ -436,11 +437,7 @@ final class ItemProviderTests_Async: XCTestCase {
                             XCTFail("Incorrect error received.")
                             return
                         }
-                    case let .decodingError(error):
-                        XCTFail("Should have received a partial retrieval error. But got \(error)")
-                    case let .networkError(error):
-                        XCTFail("Should have received a partial retrieval error. But got \(error)")
-                    case let .persistenceError(error):
+                    case .decodingError, .networkError, .persistenceError:
                         XCTFail("Should have received a partial retrieval error. But got \(error)")
                     }
                 }

--- a/Tests/TestItem.swift
+++ b/Tests/TestItem.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Provider
 
-struct TestItem: Providable {
+struct TestItem: Providable, Equatable {
     var identifier: Key { return title }
     
     let title: String


### PR DESCRIPTION
## What it Does
- Adds two methods which return an async stream of the result type. The result type success can either be a single item or a collection of items. They type of error is ProviderError.
## How I Tested
Ran the tests.
## Notes
- I considered using AsyncThrowingStream, but that type requires the error thrown to be any error. It would cause us more work on the client side to cast this error to a ProviderError. I decided against it for this reason.
- This method publishes the first response then finishes, it does not publish a continuous stream of data. The reason this method is being used over `withCheckedContinuation` is it's ability to finish. With, withCheckContinuation, when resume is called, and tried to be called a second time this would result in a concurrency crash.
- The async stream APIs are continuous I tried to make a test depicting the behavior of using `cacheAndNetwork` fetch policy. When this policy is used, with the async provides method, the cached item will be returned if any, then a request will be made to the network. The result of that operation will then be emitted.
